### PR TITLE
adds correct package name

### DIFF
--- a/localgov_job_vacancies.info.yml
+++ b/localgov_job_vacancies.info.yml
@@ -1,7 +1,7 @@
 name: 'Localgov Job Vacancies'
 type: module
 description: 'Provides a simple Job Vacancy content type, a Job Vacancies view, and accompanying fields and config.'
-package: Custom
+package: 'LocalGov Drupal'
 core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:content_moderation


### PR DESCRIPTION
Closes #7 

## What does this change?

Add correct package name for the modules listing page.

## How to test

Go to the modules listing page, search for 'Job Vacancies', make sure this module is under the 'LocalGov Drupal' package namespace.
