### PR TITLE
fix: ensures content moderation form not visible in job-vacancies view

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_job_vacancy.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_job_vacancy.search_result.yml
@@ -27,11 +27,6 @@ content:
         class: ''
     weight: 4
     region: content
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 0
-    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -47,5 +42,6 @@ content:
     weight: 3
     region: content
 hidden:
+  content_moderation_control: true
   localgov_application_forms: true
   search_api_excerpt: true


### PR DESCRIPTION
## What does this change?

Moves content_moderation_control to 'hidden' in core.entity_view_display.node.localgov_job_vacancy.search_result.yml.

Changed in `config/import` only as this module isn't in a stable form as yet.

## How to test


- check out this repo on a new LGD instance
- install the module
- create one or more Job Vacancy nodes
- visit /job-vacancies

## How can we measure success?

- moderation control form is not shown on items in the view

## Have we considered potential risks?

None, really.